### PR TITLE
Move FactoryGirl into development

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -28,10 +28,10 @@ gem_group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'quiet_assets'
+  gem 'factory_girl_rails'
 end
 
 gem_group :test do
-  gem 'factory_girl_rails'
   gem 'simplecov'
   gem 'zonebie'
 end


### PR DESCRIPTION
Moves factory girl from test to test, and development. Lets us take advantage of factorygirl's functionality for automatically creating a new factory when we generate a new model.

One downside is that there is the possibility that this will end up creating a lot of factories that we never use.
